### PR TITLE
Add split and fill mojo

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,10 @@ Configure the plugin in your `pom.xml` like this:
             </plugin>
 ```
 
-# Split mojo
+# Other mojos
 
-You can override the json files with values from a combined file like this:
+See the plugin help for details:
 
 ```
-mvn -Di18n:file=de.json -Di18n.language=de i18n:split
+mvn i18n:help -Ddetail=true
 ```
-
-This will override all keys in the given language with values set in the
-given file.

--- a/README.md
+++ b/README.md
@@ -48,3 +48,14 @@ Configure the plugin in your `pom.xml` like this:
                 </executions>
             </plugin>
 ```
+
+# Split mojo
+
+You can override the json files with values from a combined file like this:
+
+```
+mvn -Di18n:file=de.json -Di18n.language=de i18n:split
+```
+
+This will override all keys in the given language with values set in the
+given file.

--- a/pom.xml
+++ b/pom.xml
@@ -1,10 +1,11 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>i18n-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
     <version>0.0.3-SNAPSHOT</version>
     <name>i18n-maven-plugin</name>
-    <description>Maven plugin to combine/disassemble i18n json files</description>
+    <description>Maven plugin to work with i18n json files</description>
 
     <scm>
         <connection>scm:git:git://github.com/terrestris/i18n-maven-plugin.git</connection>
@@ -17,7 +18,7 @@
         <groupId>de.terrestris</groupId>
         <artifactId>terrestris-parent</artifactId>
         <version>0.1.3</version>
-        <relativePath />
+        <relativePath/>
     </parent>
 
     <repositories>
@@ -60,6 +61,14 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
                 <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <id>generated-helpmojo</id>
+                        <goals>
+                            <goal>helpmojo</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>

--- a/src/main/java/de/terrestris/maven/i18n/I18nMojo.java
+++ b/src/main/java/de/terrestris/maven/i18n/I18nMojo.java
@@ -17,6 +17,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+/**
+ * Combine small json files into a complete translation file. See the
+ * README at https://github.com/terrestris/i18n-maven-plugin/ for details.
+ * It is best integrated into your pom in the generate-resources phase.
+ */
 @Execute(goal = "combine", phase = LifecyclePhase.GENERATE_RESOURCES)
 @Mojo(name = "combine")
 public class I18nMojo extends AbstractMojo {
@@ -27,6 +32,9 @@ public class I18nMojo extends AbstractMojo {
     @Parameter
     private String pathPrefix;
 
+    /**
+     * Set to true to enable pretty printing for the output json.
+     */
     @Parameter(property = "i18n.format", defaultValue = "false")
     private boolean format;
 


### PR DESCRIPTION
Adds a mojo to parse `combine` output files and replace the keys in `combine`'s input files.

Also adds a mojo to fill i18n files with missing keys.

@terrestris/devs Please review.